### PR TITLE
feat: added a map control for theme selection

### DIFF
--- a/src/assets/theme-control.css
+++ b/src/assets/theme-control.css
@@ -1,0 +1,34 @@
+.theme-list {
+    display: none;
+}
+
+.maplibregl-ctrl-group .theme-list button {
+    background: none;
+    border: none;
+    cursor: pointer;
+    display: block;
+    font-size: 14px;
+    padding: 8px 8px 6px;
+    text-align: right;
+    width: 100%;
+    height: auto;
+}
+
+.theme-list button.active {
+    font-weight: bold;
+}
+
+.theme-list button:hover {
+    background-color: rgba(0, 0, 0, 0.05);
+}
+
+.theme-list button + button {
+    border-top: 1px solid #ddd;
+}
+
+.theme-switcher {
+    background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iaXNvLTg4NTktMSI/PjwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+PHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJDYXBhXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IiB3aWR0aD0iNTQuODQ5cHgiIGhlaWdodD0iNTQuODQ5cHgiIHZpZXdCb3g9IjAgMCA1NC44NDkgNTQuODQ5IiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1NC44NDkgNTQuODQ5OyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+PGc+PGc+PGc+PHBhdGggZD0iTTU0LjQ5NywzOS42MTRsLTEwLjM2My00LjQ5bC0xNC45MTcsNS45NjhjLTAuNTM3LDAuMjE0LTEuMTY1LDAuMzE5LTEuNzkzLDAuMzE5Yy0wLjYyNywwLTEuMjU0LTAuMTA0LTEuNzktMC4zMThsLTE0LjkyMS01Ljk2OEwwLjM1MSwzOS42MTRjLTAuNDcyLDAuMjAzLTAuNDY3LDAuNTI0LDAuMDEsMC43MTZMMjYuNTYsNTAuODFjMC40NzcsMC4xOTEsMS4yNTEsMC4xOTEsMS43MjksMEw1NC40ODgsNDAuMzNDNTQuOTY0LDQwLjEzOSw1NC45NjksMzkuODE3LDU0LjQ5NywzOS42MTR6Ii8+PHBhdGggZD0iTTU0LjQ5NywyNy41MTJsLTEwLjM2NC00LjQ5MWwtMTQuOTE2LDUuOTY2Yy0wLjUzNiwwLjIxNS0xLjE2NSwwLjMyMS0xLjc5MiwwLjMyMWMtMC42MjgsMC0xLjI1Ni0wLjEwNi0xLjc5My0wLjMyMWwtMTQuOTE4LTUuOTY2TDAuMzUxLDI3LjUxMmMtMC40NzIsMC4yMDMtMC40NjcsMC41MjMsMC4wMSwwLjcxNkwyNi41NiwzOC43MDZjMC40NzcsMC4xOSwxLjI1MSwwLjE5LDEuNzI5LDBsMjYuMTk5LTEwLjQ3OUM1NC45NjQsMjguMDM2LDU0Ljk2OSwyNy43MTYsNTQuNDk3LDI3LjUxMnoiLz48cGF0aCBkPSJNMC4zNjEsMTYuMTI1bDEzLjY2Miw1LjQ2NWwxMi41MzcsNS4wMTVjMC40NzcsMC4xOTEsMS4yNTEsMC4xOTEsMS43MjksMGwxMi41NDEtNS4wMTZsMTMuNjU4LTUuNDYzYzAuNDc3LTAuMTkxLDAuNDgtMC41MTEsMC4wMS0wLjcxNkwyOC4yNzcsNC4wNDhjLTAuNDcxLTAuMjA0LTEuMjM2LTAuMjA0LTEuNzA4LDBMMC4zNTEsMTUuNDFDLTAuMTIxLDE1LjYxNC0wLjExNiwxNS45MzUsMC4zNjEsMTYuMTI1eiIvPjwvZz48L2c+PC9nPjxnPjwvZz48Zz48L2c+PGc+PC9nPjxnPjwvZz48Zz48L2c+PGc+PC9nPjxnPjwvZz48Zz48L2c+PGc+PC9nPjxnPjwvZz48Zz48L2c+PGc+PC9nPjxnPjwvZz48Zz48L2c+PGc+PC9nPjwvc3ZnPg==);
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: 70%;
+}

--- a/src/components/JsonWebMap.vue
+++ b/src/components/JsonWebMap.vue
@@ -208,10 +208,18 @@ watch(species, () => {
 })
 
 const singleItems = computed<SelectableSingleItem[]>(() =>
-  (parameters.value?.selectableItems ?? []).flatMap((item: SelectableItem) =>
-    'children' in item ? item.children : [item]
-  )
+  (parameters.value?.selectableItems ?? [])
+    .filter((item: SelectableItem) => item.id !== 'theme')
+    .flatMap((item: SelectableItem) =>
+      'children' in item ? item.children : [item]
+    )
 )
+
+const themeItems = computed<SelectableSingleItem[]>(() => {
+  const themeGroup = parameters.value?.selectableItems?.find((item: SelectableItem) => item.id === 'theme') as SelectableGroupItem
+  return themeGroup ? themeGroup.children : []
+})
+
 const selectableLayerIds = computed<string[]>(() => singleItems.value.map((item) => item.id))
 const legendItems = computed(() =>
   singleItems.value
@@ -383,11 +391,12 @@ function showDocumentation(id: string) {
         <MapLibreMap
           ref="map"
           :center="parameters?.center"
+          :zoom="parameters?.zoom"
           :style-spec="style"
+          :themes="themeItems"
           :selectable-layer-ids="selectableLayerIds"
           :selected-layer-ids="extendedSelectedLayerIds"
           :popup-layer-ids="parameters?.popupLayerIds"
-          :zoom="parameters?.zoom"
         />
       </v-col>
     </v-row>

--- a/src/components/LayerSelector.vue
+++ b/src/components/LayerSelector.vue
@@ -20,12 +20,6 @@ const emit = defineEmits<{
   (e: 'update:modelValue', value: string[]): void
 }>()
 
-const themeIdx = ref<number>()
-const themeItems = computed<any[]>(() =>
-  props.items?.filter((item: any) => item.id === 'theme')
-    .flatMap((item: any) => item.children)
-)
-
 const genre = ref<string>()
 const genreItems = computed<any[]>(() =>
   props.species
@@ -73,21 +67,13 @@ watch(tab, () => {
   updateLayers()
 })
 
-watch([themeIdx, scale], () => {
+watch(scale, () => {
   updateLayers()
 })
 
 watch(() => props.items,
   (value: SelectableItem[]) => {
-    // init with default selected theme
-    const themeGroup = value.find((item: SelectableItem) => item.id === 'theme') as SelectableGroupItem
-    if (themeGroup) {
-      themeGroup.children.forEach((item: SelectableSingleItem, index: number) => {
-      if (item.selected)
-        themeIdx.value = index
-      })
-    }
-    // default values, while there are only the quercus_robur data
+    // init with declared species
     const speciesGroup = value.find((item: SelectableItem) => item.id === 'species') as SelectableGroupItem
     if (speciesGroup) {
       // find the genre of the default species
@@ -111,9 +97,6 @@ watch(() => props.scales,
 
 function updateLayers() {
   const sels = []
-  if (themeIdx.value !== undefined) {
-    sels.push(themeItems.value[themeIdx.value].id)
-  }
   if (tab.value) { 
     const map = selectableTabs.value.filter((item: SelectableItem) => item.id === tab.value).pop()
     if (map) {
@@ -131,18 +114,7 @@ function updateLayers() {
 <template>
   <v-card flat>
     <v-card-text class="pa-0">
-      <div>
-        <div class="mb-2 text-overline">Theme</div>
-        <v-btn-toggle
-          v-model="themeIdx"
-          divided
-          variant="outlined"
-        >
-          <v-btn v-for="(item, index) in themeItems" :key="index" size="x-small">{{ item.label }}</v-btn>
-        </v-btn-toggle>
-      </div>
       <div class="mt-2">
-        <div class="mb-2 text-overline">Trees</div>
         <v-select
           v-model="genre"
           label="Genus"

--- a/src/utils/control.ts
+++ b/src/utils/control.ts
@@ -1,4 +1,4 @@
-import type { IControl } from 'maplibre-gl'
+import type { ControlPosition, IControl, Map } from 'maplibre-gl'
 
 /**
  * https://maplibre.org/maplibre-gl-js-docs/api/markers/#icontrol
@@ -22,5 +22,159 @@ export class DivControl implements IControl {
   onRemove() {
     this.container?.parentNode?.removeChild(this.container)
     this.container = undefined
+  }
+}
+
+export type ThemeDefinition =
+{
+    id: string
+    label: string
+}
+
+export type ThemeSwitcherOptions =
+{
+    defaultStyle?: string
+    eventListeners?: ThemeSwitcherEvents
+}
+
+type ThemeSwitcherEvents =
+{
+    onOpen?: (event: MouseEvent) => boolean
+    onSelect?: (event: MouseEvent) => boolean
+    onChange?: (event: MouseEvent, style: string | undefined) => boolean
+}
+
+export class ThemeControl implements IControl {
+  private static readonly DEFAULT_STYLE = "light";
+  private static readonly DEFAULT_STYLES: ThemeDefinition[] = [
+    {
+      "id": "classic",
+      "label": "Classic"
+    },
+    {
+      "id": "light",
+      "label": "Light"
+    },
+    {
+      "id": "dark",
+      "label": "Dark"
+    }
+  ];
+
+  private controlContainer: HTMLElement | undefined;
+  private events?: ThemeSwitcherEvents;
+  private map?: Map;
+  private themeContainer: HTMLElement | undefined;
+  private styleButton: HTMLButtonElement | undefined;
+  private styles: ThemeDefinition[];
+  private defaultStyle: string;
+
+  constructor(styles?: ThemeDefinition[], options?: ThemeSwitcherOptions | string) {
+    this.styles = styles ?? ThemeControl.DEFAULT_STYLES;
+    const defaultStyle = typeof(options) === "string" ? options : options ? options.defaultStyle : undefined;
+    this.defaultStyle = defaultStyle || ThemeControl.DEFAULT_STYLE;
+    this.onDocumentClick = this.onDocumentClick.bind(this);
+    this.events = typeof(options) !== "string" && options ? options.eventListeners : undefined;
+  }
+
+  public getDefaultPosition(): ControlPosition {
+    const defaultPosition = "top-right";
+    return defaultPosition;
+  }
+
+  public onAdd(map: Map): HTMLElement {
+    this.map = map;
+    this.controlContainer = document.createElement("div");
+    this.controlContainer.classList.add("maplibregl-ctrl");
+    this.controlContainer.classList.add("maplibregl-ctrl-group");
+    this.themeContainer = document.createElement("div");
+    this.styleButton = document.createElement("button");
+    this.styleButton.type = "button";
+    this.themeContainer.classList.add("theme-list");
+    for (const style of this.styles) {
+        const styleElement = document.createElement("button");
+        styleElement.type = "button";
+        styleElement.innerText = style.label;
+        styleElement.classList.add(style.label.replace(/[^a-z0-9-]/gi, '_'));
+        styleElement.dataset.id = style.id;
+        styleElement.addEventListener("click", event => {
+          const srcElement = event.srcElement as HTMLButtonElement;
+          this.closeModal();
+          if (srcElement.classList.contains("active")) {
+            return;
+          }
+          if (this.events && this.events.onOpen && this.events.onOpen(event)) {
+            return;
+          }
+          const styleId = srcElement.dataset.id;
+          if (this.map?.loaded()) {
+            this.map?.getStyle().layers
+              .filter((layer) => this.styles.map((style) => style.id).includes(layer.id))
+              .forEach((layer) => {
+                this.map?.setLayoutProperty(
+                  layer.id,
+                  'visibility',
+                  layer.id === styleId ? 'visible' : 'none'
+                )
+              })
+          }
+          const elms = this.themeContainer!.getElementsByClassName("active");
+          while (elms[0]) {
+              elms[0].classList.remove("active");
+          }
+          srcElement.classList.add("active");
+          if (this.events && this.events.onChange && this.events.onChange(event, styleId)) {
+            return;
+          }
+        });
+        if (style.id === this.defaultStyle) {
+          styleElement.classList.add("active");
+        }
+        this.themeContainer.appendChild(styleElement);
+    }
+    this.styleButton.classList.add("maplibregl-ctrl-icon");
+    this.styleButton.classList.add("theme-switcher");
+    this.styleButton.addEventListener("click", event => {
+      if (this.events && this.events.onSelect && this.events.onSelect(event)) {
+        return;
+      }
+      this.openModal();
+    });
+
+    document.addEventListener("click", this.onDocumentClick);
+
+    this.controlContainer.appendChild(this.styleButton);
+    this.controlContainer.appendChild(this.themeContainer);
+    return this.controlContainer;
+  }
+
+  public onRemove(): void {
+    if (!this.controlContainer || !this.controlContainer.parentNode || !this.map || !this.styleButton) {
+      return;
+    }
+    this.styleButton.removeEventListener("click", this.onDocumentClick);
+    this.controlContainer.parentNode.removeChild(this.controlContainer);
+    document.removeEventListener("click", this.onDocumentClick);
+    this.map = undefined;
+  }
+
+  private closeModal(): void {
+    if (this.themeContainer && this.styleButton) {
+      this.themeContainer.style.display = "none";
+      this.styleButton.style.display = "block";
+    }
+  }
+
+  private openModal(): void {
+    if (this.themeContainer && this.styleButton) {
+      this.themeContainer.style.display = "block";
+      this.styleButton.style.display = "none";
+    }
+  }
+
+  private onDocumentClick(event: MouseEvent): void {
+    if (this.controlContainer && !this.controlContainer.contains(event.target as Element)) {
+      this.closeModal();
+    }
   }
 }


### PR DESCRIPTION
To leave some room in the left drawer, the background selection has been moved to a map control widget.

![image](https://github.com/EPFL-ENAC/alice-perl-eerl-urbtrees/assets/2581149/eff92ba7-614f-4d90-ae77-0cb843eda05f)
![image](https://github.com/EPFL-ENAC/alice-perl-eerl-urbtrees/assets/2581149/71404cf6-a963-4bd6-89c9-a2f1dcbaacf3)
